### PR TITLE
fix: Reset active connection id when a new connection is being established

### DIFF
--- a/src/hooks/use-acp-client.ts
+++ b/src/hooks/use-acp-client.ts
@@ -51,6 +51,7 @@ export interface UseAcpClientReturn {
 
   // State management
   activeSessionId: SessionId | null;
+  setActiveSessionId: (sessionId: SessionId | null) => void;
   notifications: NotificationEvent[];
   clearNotifications: () => void;
   isSessionLoading: boolean;
@@ -290,6 +291,7 @@ export function useAcpClient(options: UseAcpClientOptions): UseAcpClientReturn {
     isSessionLoading,
     clearNotifications,
     pendingPermission,
+    setActiveSessionId,
     resolvePermission,
     rejectPermission: rejectPermissionCallback,
     agent: agent,

--- a/src/hooks/use-acp-client.ts
+++ b/src/hooks/use-acp-client.ts
@@ -269,6 +269,9 @@ export function useAcpClient(options: UseAcpClientOptions): UseAcpClientReturn {
   // Auto-connect on mount if specified
   // biome-ignore lint/correctness/useExhaustiveDependencies: Don't include connect/disconnect to avoid re-connecting on every render
   useEffect(() => {
+    // Reset the active session id as the connection is being established
+    setActiveSessionId(null);
+
     if (autoConnect) {
       void connect().catch(console.error);
     }


### PR DESCRIPTION
* Added a `setActiveSessionId` function to the `UseAcpClientReturn` interface, enabling components to update or reset the active session ID.
* Reset the active session ID to `null` in the `useEffect` hook when a new connection is initiated, ensuring the session state remains consistent during reconnection.