### PR TITLE
Migrate to actual ACP SDK library

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(pnpm run build:*)",
+      "Bash(pnpm run lint:*)",
+      "Bash(pnpm run typecheck:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+use flake
+alias bash=/bin/bash

--- a/demo/components/content-block.tsx
+++ b/demo/components/content-block.tsx
@@ -1,4 +1,4 @@
-import type { ContentBlock } from "@zed-industries/agent-client-protocol";
+import type { ContentBlock } from "@agentclientprotocol/sdk";
 import type React from "react";
 import { Streamdown } from "streamdown";
 import { logNever } from "../../src/utils/never.js";

--- a/demo/components/timeline-components.tsx
+++ b/demo/components/timeline-components.tsx
@@ -1,6 +1,6 @@
 /** biome-ignore-all lint/suspicious/noArrayIndexKey: just a demo */
 
-import type { ToolCallContent, ToolCallUpdate } from "@zed-industries/agent-client-protocol";
+import type { ToolCallContent, ToolCallUpdate } from "@agentclientprotocol/sdk";
 import type React from "react";
 import { useEffect, useRef } from "react";
 import type {

--- a/demo/components/tool-call.tsx
+++ b/demo/components/tool-call.tsx
@@ -1,4 +1,4 @@
-import type { ToolCallUpdate } from "@zed-industries/agent-client-protocol";
+import type { ToolCallUpdate } from "@agentclientprotocol/sdk";
 import type { ToolCallDiff, ToolCallStart } from "../../src/client/types.js";
 import { ContentBlockComponent } from "./content-block.js";
 import { Badge, Card, CodeBlock, IconLabel, SectionHeader } from "./ui-primitives.js";

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1761114652,
+        "narHash": "sha256-f/QCJM/YhrV/lavyCVz8iU3rlZun6d+dAiC3H+CDle4=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "01f116e4df6a15f4ccdffb1bcd41096869fb385c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,28 @@
+{
+  description = "Server shell";
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    # systems.url = "github:nix-systems/default";
+  };
+  outputs =
+    { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+    in
+    {
+      devShells.${system} = {
+        default = pkgs.mkShell {
+          buildInputs = [
+            pkgs.nodePackages.pnpm
+          ];
+          packages = [
+            pkgs.bashInteractive
+          ];
+        };
+      };
+
+      # packages.${system}.hello = pkgs.hello;
+      # packages.${system}.default = self.packages.${system}.hello;
+    };
+}

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     ]
   },
   "dependencies": {
-    "@zed-industries/agent-client-protocol": "0.3.1",
+    "@agentclientprotocol/sdk": "^0.4.9",
     "zustand": "^5.0.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      '@zed-industries/agent-client-protocol':
-        specifier: 0.3.1
-        version: 0.3.1
+      '@agentclientprotocol/sdk':
+        specifier: ^0.4.9
+        version: 0.4.9
       zustand:
         specifier: ^5.0.2
         version: 5.0.8(@types/react@19.1.12)(react@19.1.1)
@@ -59,6 +59,9 @@ importers:
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.1)(happy-dom@15.11.7)(jsdom@26.1.0)(yaml@2.8.0)
 
 packages:
+
+  '@agentclientprotocol/sdk@0.4.9':
+    resolution: {integrity: sha512-ExwH828LaTGoTTjxuw49l+fwOLA+Yx0+qkWn1TcHMOsY5mVI9CUfkj7ZDhv2klgZ7mJeT+lxX/Dn/KINv1AkNQ==}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -692,10 +695,6 @@ packages:
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
-
-  '@zed-industries/agent-client-protocol@0.3.1':
-    resolution: {integrity: sha512-G3gGwNZ18vuuo6rDCo8eoGs/V/P2stIMV7srlaTNXf3u8qAoUNm91p2qhMurR/bCebq8J8yWCKuBZXdC/E162w==}
-    deprecated: This package has been renamed to @agentclientprotocol/sdk. Please migrate to continue receiving updates.
 
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
@@ -2094,6 +2093,10 @@ packages:
 
 snapshots:
 
+  '@agentclientprotocol/sdk@0.4.9':
+    dependencies:
+      zod: 3.25.76
+
   '@ampproject/remapping@2.3.0':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.8
@@ -2652,10 +2655,6 @@ snapshots:
       '@vitest/pretty-format': 3.2.4
       loupe: 3.2.0
       tinyrainbow: 2.0.0
-
-  '@zed-industries/agent-client-protocol@0.3.1':
-    dependencies:
-      zod: 3.25.76
 
   acorn@8.15.0: {}
 

--- a/src/client/acp-client.ts
+++ b/src/client/acp-client.ts
@@ -16,10 +16,12 @@ import type {
   RequestPermissionRequest,
   RequestPermissionResponse,
   SessionNotification,
+  SetSessionModelRequest,
+  SetSessionModelResponse,
   SetSessionModeRequest,
   WriteTextFileRequest,
   WriteTextFileResponse,
-} from "@zed-industries/agent-client-protocol";
+} from "@agentclientprotocol/sdk";
 import { Deferred } from "../utils/deferred.js";
 
 export interface AcpClientOptions {
@@ -136,6 +138,16 @@ export class ListeningAgent implements Required<Agent> {
       this.callbacks.on_setSessionMode_response?.(response, params);
       return response;
     });
+  }
+
+  async setSessionModel(
+    params: SetSessionModelRequest,
+    // biome-ignore lint/suspicious/noConfusingVoidType: Matches Agent interface signature
+  ): Promise<SetSessionModelResponse | void> {
+    this.callbacks.on_setSessionModel_start?.(params);
+    const result = await this.agent.setSessionModel?.(params);
+    this.callbacks.on_setSessionModel_response?.(result, params);
+    return result;
   }
 
   async initialize(params: InitializeRequest): Promise<InitializeResponse> {

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -1,4 +1,4 @@
-import type { SessionNotification, ToolCallContent } from "@zed-industries/agent-client-protocol";
+import type { SessionNotification, ToolCallContent } from "@agentclientprotocol/sdk";
 
 export type SessionUpdate = SessionNotification["update"];
 

--- a/src/hooks/use-acp-client.ts
+++ b/src/hooks/use-acp-client.ts
@@ -4,10 +4,11 @@ import {
   type AvailableCommand,
   ClientSideConnection,
   type McpServer,
+  ndJsonStream,
   type RequestPermissionResponse,
   type SessionModeState,
   type SessionNotification,
-} from "@zed-industries/agent-client-protocol";
+} from "@agentclientprotocol/sdk";
 import { useEffect, useRef, useState } from "react";
 import {
   AcpClient,
@@ -175,8 +176,7 @@ export function useAcpClient(options: UseAcpClientOptions): UseAcpClientReturn {
         acpClientRef.current = acpClient;
         return acpClient;
       },
-      writable,
-      readable as ReadableStream<Uint8Array>,
+      ndJsonStream(writable, readable as ReadableStream<Uint8Array>),
     );
 
     const listeningAgent: Agent = new ListeningAgent(agent, {

--- a/src/state/atoms.ts
+++ b/src/state/atoms.ts
@@ -1,8 +1,4 @@
-import type {
-  AgentCapabilities,
-  SessionModeId,
-  SessionModeState,
-} from "@zed-industries/agent-client-protocol";
+import type { AgentCapabilities, SessionModeId, SessionModeState } from "@agentclientprotocol/sdk";
 import { create } from "zustand";
 import type {
   Connection,

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -1,4 +1,4 @@
-import type { AgentCapabilities, SessionNotification } from "@zed-industries/agent-client-protocol";
+import type { AgentCapabilities, SessionNotification } from "@agentclientprotocol/sdk";
 
 export type AgentId = string & { __brand: "AgentId" };
 export type SessionId = string & { __brand: "SessionId" };

--- a/src/state/utils.ts
+++ b/src/state/utils.ts
@@ -1,4 +1,4 @@
-import type { ToolCallUpdate } from "@zed-industries/agent-client-protocol";
+import type { ToolCallUpdate } from "@agentclientprotocol/sdk";
 import type { SessionUpdate } from "../client/types.js";
 import { invariant } from "../utils/never.js";
 import type { NotificationEvent } from "./types.js";


### PR DESCRIPTION
Migrate from deprecated @zed-industries/agent-client-protocol@0.3.1 to @agentclientprotocol/sdk@^0.4.9, resolve deprecation warning

Changes:
- Update package dependency in package.json
- Replace all imports across 9 source files
- Add setSessionModel method to ListeningAgent class
- Update ClientSideConnection to use ndJsonStream wrapper

All type signatures remain compatible. Tests and build passing.

Resolves #1 