### PR TITLE
only get notification from appropriate session id

### DIFF
--- a/demo/acp-demo.tsx
+++ b/demo/acp-demo.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { useAcpClient } from "../src/hooks/use-acp-client.js";
+import type { SessionId } from "../src/state/types.js";
 import { JsonRpcError } from "../src/utils/jsonrpc-error.js";
 import { NotificationTimeline } from "./components/timeline-components.js";
 import { ToolCall } from "./components/tool-call.js";
@@ -587,7 +588,7 @@ function AcpDemo() {
               )}
             </div>
             <button
-              onClick={clearNotifications}
+              onClick={() => activeSessionId && clearNotifications(activeSessionId as SessionId)}
               type="button"
               className="text-sm text-gray-500 hover:text-gray-700 px-3 py-1 border border-gray-300 rounded-md hover:bg-gray-100"
             >

--- a/src/hooks/use-acp-client.ts
+++ b/src/hooks/use-acp-client.ts
@@ -54,7 +54,7 @@ export interface UseAcpClientReturn {
   activeSessionId: SessionId | null;
   setActiveSessionId: (sessionId: SessionId | null) => void;
   notifications: NotificationEvent[];
-  clearNotifications: () => void;
+  clearNotifications: (sessionId?: SessionId) => void;
   isSessionLoading: boolean;
 
   // Permission handling

--- a/src/state/atoms.ts
+++ b/src/state/atoms.ts
@@ -155,7 +155,15 @@ export const useAcpStore = create<AcpState>((set, get) => ({
 
   addNotification: (notification: NotificationEventData) => {
     const current = get().notifications;
-    const sessionId = get().activeSessionId;
+
+    // We prefer using the sessionId from the notification itself, because it may not be the same as the activeSessionId.
+    let sessionId: SessionId | null;
+    if (notification.type === "session_notification" && notification.data?.sessionId) {
+      sessionId = notification.data.sessionId as SessionId;
+    } else {
+      sessionId = get().activeSessionId;
+    }
+
     if (!sessionId) {
       return;
     }


### PR DESCRIPTION
Related to an opencode bug where we get duplicated notifications (after restart, we receive notifications from multiple sessions). Opencode may have a bug where it's sending notifications from multiple sessions, this is just a correctness fix.