### PR TITLE
chore(ci): add --ignore-scripts to global npm install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           cache: pnpm
 
       - name: Upgrade npm for OIDC support
-        run: npm install -g npm@latest
+        run: npm install --ignore-scripts -g npm@latest
 
       - name: 📥 Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
`pnpm install` lifecycle scripts are already restricted by pnpm 10 (`onlyBuiltDependencies` allowlist), so the flag adds no protection there. Global `npm install` runs scripts by default, so the flag does add protection.

Defense-in-depth motivated by the TanStack npm supply-chain compromise (May 2026).