### PR TITLE
ci: adopt deny-all top-level workflow permissions

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -5,8 +5,7 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   build:
@@ -38,6 +37,8 @@ jobs:
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: './demo/dist'
+    permissions:
+      contents: read
 
   deploy:
     name: 🚀 Deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,6 @@
 name: Release
 
-permissions:
-  contents: read
+permissions: {}
 
 on:
   push:
@@ -72,6 +71,8 @@ jobs:
             LICENSE
           retention-days: 1
           if-no-files-found: error
+    permissions:
+      contents: read
 
   publish:
     runs-on: ubuntu-latest
@@ -130,3 +131,5 @@ jobs:
           status: ${{ (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) && 'failure' || 'success' }}
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL_RELEASES }}
           artifact-url: "https://npmjs.com/package/@marimo-team/use-acp"
+    permissions:
+      contents: read


### PR DESCRIPTION
Sets each workflow's top-level `permissions:` to `{}` (deny-all) and moves the previously top-level grants into the specific jobs that inherited them. **Effective permissions are unchanged for every job** — this just makes the grants explicit per job so a newly-added job can't silently inherit broad scopes.

Behavior-preserving mechanical change (validated: all touched workflows still parse; per-job effective scopes identical). Workflows whose jobs inherit the org default are left untouched for a manual per-job pass.

_Flagged by github-maintenance Workflow Permissions Audit._