### PR TITLE
ci: enforce lint and report coverage on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,11 +35,20 @@ jobs:
       - name: 📥 Install dependencies
         run: pnpm install --ignore-scripts --frozen-lockfile
 
+      - name: 🧹 Lint
+        run: pnpm run lint:ci
+
       - name: 🔍 Type Check
         run: pnpm run typecheck
 
       - name: 🧪 Test
         run: pnpm run test
+
+      - name: 📊 Report Coverage
+        if: always()
+        uses: davelosert/vitest-coverage-report-action@3c50566c523e04813df28de8f7c48dd97d663f1c # v2
+        with:
+          pr-number: auto
 
   security:
     runs-on: ubuntu-latest

--- a/biome.json
+++ b/biome.json
@@ -39,5 +39,10 @@
       "semicolons": "always",
       "indentStyle": "space"
     }
+  },
+  "css": {
+    "parser": {
+      "tailwindDirectives": true
+    }
   }
 }

--- a/demo/components/tool-call.tsx
+++ b/demo/components/tool-call.tsx
@@ -90,6 +90,7 @@ export function ToolCall({ toolCall }: ToolCallProps) {
           <IconLabel icon="📍" label="Locations" size="sm" className="mb-2 text-gray-700" />
           <div className="flex flex-wrap gap-1">
             {toolCall.locations?.map((location, index) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: index only disambiguates duplicate location paths in demo data
               <Badge key={`${location.path}-${index}`} variant="default" size="md">
                 <code className="text-xs">
                   {location.line ? `${location.path}:${location.line}` : location.path}
@@ -107,10 +108,12 @@ export function ToolCall({ toolCall }: ToolCallProps) {
           <div className="space-y-4">
             {toolCall.content?.map((item, index) => {
               if (item.type === "diff") {
+                // biome-ignore lint/suspicious/noArrayIndexKey: index only disambiguates repeated content types in demo data
                 return <DiffContent key={`${item.type}-${index}`} diff={item} />;
               }
               if (item.type === "content") {
                 return (
+                  // biome-ignore lint/suspicious/noArrayIndexKey: index only disambiguates repeated content types in demo data
                   <ContentBlockComponent key={`${item.type}-${index}`} content={item.content} />
                 );
               }

--- a/demo/components/ui-primitives.tsx
+++ b/demo/components/ui-primitives.tsx
@@ -175,6 +175,7 @@ export function MetadataList({ items, className = "" }: MetadataListProps) {
   return (
     <div className={`space-y-1 ${className}`}>
       {items.map((item, index) => (
+        // biome-ignore lint/suspicious/noArrayIndexKey: index only disambiguates duplicate metadata labels in demo data
         <div key={`${item.label}-${index}`} className="flex items-center justify-between text-xs">
           <span className="text-gray-500 opacity-70">{item.label}:</span>
           <span className="text-gray-700 font-mono">{item.value}</span>

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dev": "vite",
     "typecheck": "tsc --noEmit",
     "lint": "biome check --write",
+    "lint:ci": "biome check",
     "test": "vitest",
     "demo": "vite build",
     "build": "tsc",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,13 @@ export default defineConfig({
   root: process.env.VITEST ? "." : "demo",
   test: {
     environment: "jsdom",
+    coverage: {
+      enabled: true,
+      include: ["src/**"],
+      exclude: ["demo/**", "scripts/**"],
+      reportOnFailure: true,
+      reporter: ["text", "html", "json-summary", "json"],
+    },
     watch: false,
   },
   base: "/use-acp/",


### PR DESCRIPTION
## What

Enforce lint in CI and surface test coverage on PRs.

- **Lint**: `biome.json` has long existed, but CI never ran it — the only `lint` script was `biome check --write` (mutating), unsuitable for CI. Added a non-mutating `lint:ci` (`biome check`) script and a `🧹 Lint` step to `test.yml`.
- **Coverage**: no coverage was configured. Added the codemirror-mcp-style setup — a `coverage` block in `vite.config.ts` (`enabled: true`, `reportOnFailure: true`, `reporter: [text, html, json-summary, json]`), and wired up the SHA-pinned `davelosert/vitest-coverage-report-action` step (mirrors marimo-team/codemirror-mcp). `@vitest/coverage-v8` was already a dev dependency; `coverage/` is already gitignored.

## Why

Lint config existed but CI never enforced it, so violations could land silently; coverage was never reported on PRs. Part of the marimo-team engineering-excellence initiative to bring the codemirror-family repos to a consistent CI baseline.

## Mechanical lint fixes

Enabling `biome check` in CI required the existing tree to pass. Two things needed attention (both in `demo/`, no product code changed):
- `demo/global.css` uses Tailwind v4 directives (`@source`) that Biome's CSS parser rejects by default — enabled `css.parser.tailwindDirectives` in `biome.json`.
- Four `noArrayIndexKey` findings on deliberate composite keys (`${semantic}-${index}`, where the index only disambiguates) in demo components — suppressed with targeted `// biome-ignore` comments and reasons.

## Verification

- `pnpm install`
- `pnpm run lint:ci` → clean (`biome check`, 26 files, no errors)
- `pnpm run typecheck` (tsc) → clean
- `pnpm run test` → tests pass; `coverage/coverage-summary.json` generated
