### PR TITLE
ci: add autofix.ci

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,39 @@
+name: autofix.ci # needed to securely identify the workflow
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: ⎔ Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - name: ⎔ Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: 📥 Install dependencies
+        run: pnpm install --ignore-scripts --frozen-lockfile
+
+      # Apply Biome's formatting/lint fixes. Unfixable lint errors are CI's job
+      # to report (see test.yml); don't let them block uploading the fixes.
+      - name: 🧹 Apply fixes
+        run: pnpm run lint || true
+
+      - uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4


### PR DESCRIPTION
## What this does

Adds an `autofix.ci` workflow that runs on every PR (and on pushes to `main`). It installs deps exactly like the repo's own CI, runs Biome's fixer (`biome check --write` via the existing `lint` script), and hands the result to `autofix-ci/action`, which **pushes the formatting/lint fixes back onto the PR branch**. Contributors never have to hand-fix formatting.

The [autofix.ci GitHub App](https://autofix.ci) is installed org-wide for `marimo-team` (confirmed by an org admin), so this works as soon as it's merged — no per-repo setup needed.

## How it composes with the existing lint gate

This does not replace CI's lint check — it complements it. The existing `test.yml`/`ci.yml` lint step stays the hard gate that fails the build on unfixable problems. autofix.ci just removes the busywork: anything Biome *can* fix automatically gets pushed to the branch, so the lint gate only ever fails on things that genuinely need a human. The fixer runs with `|| true` so unfixable lint errors don't block uploading the fixes that did apply (CI still reports them).

## Verification

- Cloned, `pnpm install`, ran the exact fixer the workflow uses — working tree stayed clean.
- Workflow YAML parses and passes `actionlint` (0 issues).
- Action/toolchain versions and SHA pins mirror the repo's existing CI workflow.
- Workflow `name` is exactly `autofix.ci` (required — the service identifies the workflow by name for security) and the `autofix-ci/action` step runs last.

Part of the marimo-team engineering-excellence initiative.
